### PR TITLE
Add large-scale scikit-allel benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install scikit-allel scipy scikit-learn pytest
+
+      - name: Run documentation examples
+        run: python docs_examples.py


### PR DESCRIPTION
## Summary
- add benchmarking utilities and large-scale simulation helpers to exercise scikit-allel doc examples at 1,000x and 1,000,000x scale
- extend every documentation test to benchmark the original example alongside two realistic, larger simulated datasets and assert on their outputs
- emit a consolidated benchmark summary once pytest completes
- add a GitHub Actions workflow that provisions Python dependencies and runs `docs_examples.py`

## Testing
- python docs_examples.py

------
https://chatgpt.com/codex/tasks/task_e_68d2dd0b1540832eb2b269233fbb4c35