### PR TITLE
Scale largest benchmarks to ~1 GiB

### DIFF
--- a/runs.py
+++ b/runs.py
@@ -298,9 +298,9 @@ def _simulate_weir_genotypes(scale_label: str) -> tuple[Any, list[list[int]]]:
     configs = {
         "x1000": (200, 100, 1000),
         "x1e6": (4000, 5000, 1_000_000),
-        # Keep the "LARGEST" dataset dramatically larger than the million-scale run
-        # while staying inside the CI disk limits (~44M diploid genotypes ≈ 0.08 GiB).
-        LARGEST_SCALE_LABEL: (5_500, 8_000, None),
+        # Push the "LARGEST" dataset close to 1 GiB of diploid genotypes while
+        # remaining comfortably above the million-scale configuration.
+        LARGEST_SCALE_LABEL: (16_384, 32_768, None),
 
 
     }
@@ -370,9 +370,9 @@ def _simulate_haplotype_array(scale_label: str, *, include_missing_row: bool = F
     configs = {
         "x1000": (100, None, 1000),
         "x1e6": (5000, None, 1_000_000),
-        # Scale the "LARGEST" haplotype data well past the million-scale scenario
-        # while remaining within CI storage budgets (~73M haplotypes ≈ 0.07 GiB).
-        LARGEST_SCALE_LABEL: (5_500, 6_656, None),
+        # Scale the "LARGEST" haplotype data to roughly 1 GiB of haplotype calls,
+        # providing a stress case far beyond the million-scale scenario.
+        LARGEST_SCALE_LABEL: (32_768, 16_384, None),
 
 
     }
@@ -459,9 +459,9 @@ def _simulate_sequence_genotypes(scale_label: str) -> tuple[Any, Any]:
     configs = {
         "x1000": (360, 50, 1000),
         "x1e6": (6000, 3000, 1_000_000),
-        # Expand the "LARGEST" sequence dataset far beyond the million-scale baseline
-        # without recreating the original disk usage issue (~44M diploid calls ≈ 0.08 GiB).
-        LARGEST_SCALE_LABEL: (8_000, 5_500, None),
+        # Expand the "LARGEST" sequence dataset to around 1 GiB of diploid genotypes
+        # while remaining comfortably beyond the million-scale baseline.
+        LARGEST_SCALE_LABEL: (16_384, 32_768, None),
 
     }
 
@@ -525,9 +525,9 @@ def _simulate_pca_matrix(scale_label: str) -> Any:
     configs = {
         "x1000": (120, 100, 1000),
         "x1e6": (4000, 3000, 1_000_000),
-        # Increase the "LARGEST" PCA matrix substantially beyond the million-scale case
-        # while keeping the generated matrix manageable for CI runners (~44M floats ≈ 0.17 GiB).
-        LARGEST_SCALE_LABEL: (8_000, 5_500, None),
+        # Grow the "LARGEST" PCA matrix to approximately 1 GiB of float32 data while
+        # significantly exceeding the million-scale case.
+        LARGEST_SCALE_LABEL: (16_384, 16_384, None),
 
     }
 


### PR DESCRIPTION
## Summary
- expand the LARGEST-scale Weir, haplotype, sequence, and PCA benchmark datasets to hit roughly a gigabyte each
- update inline documentation to reflect the new stress-test targets

## Testing
- python -m compileall runs.py

------
https://chatgpt.com/codex/tasks/task_e_68d35c6e8470832e8a02b6fc408ba4d0