### PR TITLE
Add benchmark TSV artifact generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,10 @@ jobs:
 
       - name: Benchmarks
         run: python runs.py
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmark-results.tsv
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- capture benchmark results, timings, and outputs in runs.py and persist them to a TSV file
- upload the generated benchmark-results.tsv as a GitHub Actions artifact

## Testing
- RUN_LARGEST_SCALE=0 python runs.py


------
https://chatgpt.com/codex/tasks/task_e_68d364e7b0e0832ebe162520faa59e71