### PR TITLE
Add library filters and split benchmark artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
-          path: benchmark-results.tsv
+          path: |
+            benchmark-results-ferromic.tsv
+            benchmark-results-scikit-allel.tsv
           if-no-files-found: error

--- a/.github/workflows/manual-bench.yml
+++ b/.github/workflows/manual-bench.yml
@@ -36,5 +36,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results-run-${{ matrix.run }}
-          path: benchmark-results.tsv
+          path: |
+            benchmark-results-ferromic.tsv
+            benchmark-results-scikit-allel.tsv
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- add CLI flags and supporting helpers to enable ferromic-only or scikit-allel-only benchmark runs
- gate benchmark calls/tests on the selected libraries and add ferromic-only smoke tests
- update GitHub workflows to upload separate ferromic and scikit-allel TSV artifacts

## Testing
- python runs.py --ferromic *(fails: process killed by OOM while running large ferromic datasets)*

------
https://chatgpt.com/codex/tasks/task_e_68d40e3bc234832eab368003431b5923