### PR TITLE
Fix CI pip cache purge failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     env:
       RUN_LARGEST_SCALE: "1"
       RUN_FERROMIC_BIG_SCALE: "1"
-      PIP_NO_CACHE_DIR: "1"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- remove the global PIP_NO_CACHE_DIR environment variable from the CI workflow so that `pip cache purge` can run

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd6ad3248832ea68c3055ef74c06f