### PR TITLE
Handle disabled pip cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,17 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Purge pip cache
-        run: python -m pip cache purge
-        env:
-          PIP_NO_CACHE_DIR: "0"
+        shell: bash
+        run: |
+          set -euo pipefail
+          CACHE_DIR=$(python -m pip cache dir 2>/dev/null || true)
+          if [ -z "$CACHE_DIR" ]; then
+            echo "Pip cache is disabled; skipping purge."
+          elif [ ! -d "$CACHE_DIR" ]; then
+            echo "Pip cache directory '$CACHE_DIR' does not exist; skipping purge."
+          else
+            python -m pip cache purge
+          fi
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- avoid failing the CI workflow when the pip cache is disabled by checking for a cache directory before purging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdb2b05f0832ea18b800894ed2f99